### PR TITLE
1.0.1

### DIFF
--- a/android/build.gradle.kts
+++ b/android/build.gradle.kts
@@ -27,8 +27,8 @@ android {
         applicationId = "com.bselzer.gw2.manager.android"
         minSdk = 21
         targetSdk = 31
-        versionCode = 1
-        versionName = "1.0.0"
+        versionCode = 2
+        versionName = "1.0.1"
 
         testInstrumentationRunner = "androidx.test.runner.AndroidJUnitRunner"
     }

--- a/android/src/main/java/com/bselzer/gw2/manager/android/wvw/WvwSelectedObjectivePage.kt
+++ b/android/src/main/java/com/bselzer/gw2/manager/android/wvw/WvwSelectedObjectivePage.kt
@@ -73,12 +73,14 @@ class WvwSelectedObjectivePage(
             }
         }
 
+        val verticalScroll = rememberScrollState()
         HorizontalPager(
             count = tabs.size,
             state = pagerState,
+            verticalAlignment = Alignment.Top,
             modifier = Modifier
                 .fillMaxWidth()
-                .verticalScroll(rememberScrollState())
+                .verticalScroll(verticalScroll)
         ) { index ->
             when (tabs[index]) {
                 DETAILS -> DetailsColumn()
@@ -86,6 +88,11 @@ class WvwSelectedObjectivePage(
                 GUILD_IMPROVEMENTS -> GuildUpgradeColumn(tiers = state.improvementTiers.value)
                 GUILD_TACTICS -> GuildUpgradeColumn(tiers = state.tacticTiers.value)
             }
+        }
+
+        LaunchedEffect(selectedIndex) {
+            // Reset to the top of the page when changing pages.
+            verticalScroll.animateScrollTo(0)
         }
     }
 
@@ -116,7 +123,7 @@ class WvwSelectedObjectivePage(
     @Composable
     private fun ContentColumn(vararg contents: @Composable ColumnScope.() -> Unit) = DividedColumn(
         horizontalAlignment = Alignment.CenterHorizontally,
-        modifier = Modifier.fillMaxSize(),
+        modifier = Modifier.fillMaxWidth(),
         divider = { Spacer(modifier = Modifier.height(10.dp)) },
         prepend = true,
         append = true,

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -20,7 +20,7 @@ buildscript {
 
 allprojects {
     group = "com.bselzer.gw2.manager"
-    version = "1.0.0"
+    version = "1.0.1"
 
     repositories {
         google()

--- a/common/src/commonMain/kotlin/com/bselzer/gw2/manager/common/state/map/MapPageType.kt
+++ b/common/src/commonMain/kotlin/com/bselzer/gw2/manager/common/state/map/MapPageType.kt
@@ -1,0 +1,6 @@
+package com.bselzer.gw2.manager.common.state.map
+
+enum class MapPageType {
+    MAP,
+    SELECTED
+}

--- a/common/src/commonMain/kotlin/com/bselzer/gw2/manager/common/state/map/WvwMapState.kt
+++ b/common/src/commonMain/kotlin/com/bselzer/gw2/manager/common/state/map/WvwMapState.kt
@@ -11,6 +11,7 @@ import com.bselzer.gw2.manager.common.state.WvwHelper.color
 import com.bselzer.gw2.manager.common.state.WvwHelper.objective
 import com.bselzer.gw2.manager.common.state.WvwHelper.selectedDateFormatted
 import com.bselzer.gw2.manager.common.state.core.Gw2State
+import com.bselzer.gw2.manager.common.state.core.PageType
 import com.bselzer.gw2.v2.cache.instance.ContinentCache
 import com.bselzer.gw2.v2.model.continent.Continent
 import com.bselzer.gw2.v2.model.continent.ContinentFloor
@@ -48,6 +49,18 @@ class WvwMapState(
     val floor = mutableStateOf<ContinentFloor?>(null)
     val horizontalScroll: ScrollState = ScrollState(0)
     val verticalScroll: ScrollState = ScrollState(0)
+
+    // TODO interface
+    private val subpage = mutableStateOf(MapPageType.MAP)
+    val currentSubpage: State<MapPageType> = subpage
+
+    /**
+     * Changes the [currentSubpage] to the new [page].
+     */
+    fun changeSubpage(page: MapPageType) {
+        Logger.d("Changing the current subpage from ${currentSubpage.value} to $page.")
+        subpage.value = page
+    }
 
     /**
      * Updates the zoom to be within the configured range.

--- a/desktop/build.gradle.kts
+++ b/desktop/build.gradle.kts
@@ -29,7 +29,7 @@ compose.desktop {
         nativeDistributions {
             targetFormats(TargetFormat.Dmg, TargetFormat.Msi, TargetFormat.Deb)
             packageName = "jvm"
-            packageVersion = "1.0.0"
+            packageVersion = "1.0.1"
         }
     }
 }


### PR DESCRIPTION
Reset the scroll offset when changing the objective detail pages.
Remember that the objective detail section was displayed when opening the navigation drawer.